### PR TITLE
Update to gesture.rb to make it work with Ruby 1.8

### DIFF
--- a/lib/leap/motion/ws/gesture.rb
+++ b/lib/leap/motion/ws/gesture.rb
@@ -26,7 +26,7 @@ module LEAP
           unless data.has_key? "type"
             raise Error, "gesture type unknown"
           end
-          name = data["type"][0].upcase << data["type"][1..-1]
+          name = data["type"][0,1].upcase << data["type"][1..-1]
           unless class_exists?(name)
             raise Error, "gesture class `#{self}::#{name}' invalid"
           end


### PR DESCRIPTION
"String"[n] on Ruby 1.8 returns an integer (explained at http://stackoverflow.com/questions/2730854/ruby-how-to-get-the-first-character-of-a-string)
